### PR TITLE
Fix sidebar layout

### DIFF
--- a/tw/share/tiddlers/$__state_sidebar.tid
+++ b/tw/share/tiddlers/$__state_sidebar.tid
@@ -3,6 +3,4 @@ modified: 20181220090702251
 tags: 
 title: $:/state/sidebar
 type: text/vnd.tiddlywiki
-
-no
-
+text: no

--- a/tw/share/tiddlers/Index.tid
+++ b/tw/share/tiddlers/Index.tid
@@ -5,7 +5,7 @@ title: Index
 type: text/vnd.tiddlywiki
 
 <<<
-This a [[Quine|https://en.wikipedia.org/wiki/Quine_(computing)]]
+This is a [[Quine|https://en.wikipedia.org/wiki/Quine_(computing)]]
 
 * It's a Blog.
 * It's interactive.

--- a/tw/share/tiddlers/styles.tid
+++ b/tw/share/tiddlers/styles.tid
@@ -22,8 +22,8 @@ type: text/vnd.tiddlywiki
 
 	html .tc-sidebar-scrollable {
 		text-align: left;
-		left: 300px;
+		left: 50%;
 		right: 0;
-		margin-left: 343px;
+		margin-left: 200px;
 	}
 }


### PR DESCRIPTION
Fixes the sidebar being overlapped by the story river.

Before:

<img width="1269" alt="image" src="https://user-images.githubusercontent.com/174761/50549383-dd87e380-0c53-11e9-83d7-c69e0c7e3ff1.png">

After:

<img width="1271" alt="image" src="https://user-images.githubusercontent.com/174761/50549384-e7114b80-0c53-11e9-8cb6-5d019df17635.png">
